### PR TITLE
Require python version > 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(name='myougiden',
           'romkan',
           'termcolor',
           ],
+      python_requires='>=3',
       classifiers=[
           'Development Status :: 4 - Beta',
           'Environment :: Console',


### PR DESCRIPTION
Prevent installation with python 2
Fix #8